### PR TITLE
feat: SJRA-85 add missing fields

### DIFF
--- a/backend/cmd/api/integration_test.go
+++ b/backend/cmd/api/integration_test.go
@@ -68,7 +68,7 @@ func Test_OccurrencesList(t *testing.T) {
 func Test_OccurrencesList_Return_Filtered_Occurrences_When_Sqon_Specified(t *testing.T) {
 	body := `{
 			"selected_fields":[
-				"seq_id","locus_id","filter","zygosity","pf","af","hgvsg","ad_ratio","variant_class"
+				"seq_id","locus_id","filter","zygosity","pf","pc","af","hgvsg","ad_ratio","variant_class"
 			],
 			"sqon":{
 				"op":"in",
@@ -78,7 +78,7 @@ func Test_OccurrencesList_Return_Filtered_Occurrences_When_Sqon_Specified(t *tes
 				}
 		}
 		}`
-	expected := `[{"ad_ratio":1, "af":0.01, "filter":"PASS", "hgvsg":"hgvsg1", "locus_id":1000, "pf":0.99, "seq_id":1, "variant_class":"class1", "zygosity":"HET"}]`
+	expected := `[{"ad_ratio":1, "af":0.01, "filter":"PASS", "hgvsg":"hgvsg1", "locus_id":1000, "pf":0.99, "pc":3, "seq_id":1, "variant_class":"class1", "zygosity":"HET"}]`
 	testList(t, "multiple", body, expected)
 
 }
@@ -135,7 +135,7 @@ func Test_Aggregation(t *testing.T) {
 func Test_Filter_On_Consequence_Column(t *testing.T) {
 	body := `{
 			"selected_fields":[
-				"seq_id","locus_id","filter","zygosity","pf","af","hgvsg","ad_ratio","variant_class"
+				"seq_id","locus_id","filter","zygosity","pf","pc","af","hgvsg","ad_ratio","variant_class"
 			],
 			"sqon": {
 				"op": "and",
@@ -152,7 +152,7 @@ func Test_Filter_On_Consequence_Column(t *testing.T) {
 			},
 			"size": 10
 		}`
-	expected := `[{"ad_ratio":1, "af":0.01, "filter":"PASS", "hgvsg":"hgvsg1", "locus_id":1000, "pf":0.99, "seq_id":1, "variant_class":"class1", "zygosity":"HET"}]`
+	expected := `[{"ad_ratio":1, "af":0.01, "filter":"PASS", "hgvsg":"hgvsg1", "locus_id":1000, "pf":0.99, "pc":3, "seq_id":1, "variant_class":"class1", "zygosity":"HET"}]`
 	testList(t, "multiple", body, expected)
 }
 

--- a/backend/internal/repository/starrocks_repository.go_test.go
+++ b/backend/internal/repository/starrocks_repository.go_test.go
@@ -38,6 +38,7 @@ func Test_GetOccurrences(t *testing.T) {
 			assert.Equal(t, "PASS", occurrences[0].Filter)
 			assert.Equal(t, "HET", occurrences[0].Zygosity)
 			assert.Equal(t, 0.99, occurrences[0].Pf)
+			assert.Equal(t, 3, occurrences[0].Pc)
 			assert.Equal(t, 0.01, occurrences[0].Af)
 			assert.Equal(t, "hgvsg1", occurrences[0].Hgvsg)
 			assert.Equal(t, 1.0, occurrences[0].AdRatio)
@@ -152,6 +153,7 @@ func Test_GetOccurrences_Return_Occurrences_That_Match_Filters(t *testing.T) {
 			assert.Equal(t, "PASS", occurrences[0].Filter)
 			assert.Equal(t, "HET", occurrences[0].Zygosity)
 			assert.Equal(t, 0.99, occurrences[0].Pf)
+			assert.Equal(t, 3, occurrences[0].Pc)
 			assert.Equal(t, 0.01, occurrences[0].Af)
 			assert.Equal(t, "hgvsg1", occurrences[0].Hgvsg)
 			assert.Equal(t, 1.0, occurrences[0].AdRatio)
@@ -301,7 +303,7 @@ func Test_GetOccurrences_Return_Expected_Occurrences_When_Filter_By_Impact_Score
 		sqon := &types.Sqon{
 			Content: types.SqonArray{
 				{Op: ">", Content: &types.LeafContent{Field: "impact_score", Value: 2}},
-				{Op: ">", Content: &types.LeafContent{Field: "gq", Value: 50}},
+				{Op: ">", Content: &types.LeafContent{Field: "genotype_quality", Value: 50}},
 			},
 			Op: "and",
 		}

--- a/backend/internal/server/handlers_test.go
+++ b/backend/internal/server/handlers_test.go
@@ -21,15 +21,19 @@ func (m *MockRepository) CheckDatabaseConnection() string {
 func (m *MockRepository) GetOccurrences(int, types.ListQuery) ([]types.Occurrence, error) {
 	return []types.Occurrence{
 		{
-			SeqId:        1,
-			LocusId:      1000,
-			Filter:       "PASS",
-			Zygosity:     "HET",
-			Pf:           0.99,
-			Af:           0.01,
-			Hgvsg:        "hgvsg1",
-			AdRatio:      1.0,
-			VariantClass: "class1",
+			SeqId:              1,
+			LocusId:            1000,
+			Filter:             "PASS",
+			Zygosity:           "HET",
+			Pf:                 0.99,
+			Pc:                 3,
+			Af:                 0.01,
+			Hgvsg:              "hgvsg1",
+			AdRatio:            1.0,
+			VariantClass:       "class1",
+			RsNumber:           "rs111111111",
+			AaChange:           "p.Arg19His",
+			PickedConsequences: []string{"splice acceptor"},
 		},
 	}, nil
 }
@@ -66,7 +70,7 @@ func Test_OccurrencesListHandler(t *testing.T) {
 	router.POST("/occurrences/:seq_id/list", OccurrencesListHandler(repo))
 	body := `{
 			"selected_fields":[
-				"seq_id","locus_id","filter","zygosity","pf","af","hgvsg","ad_ratio","variant_class"
+				"seq_id","locus_id","filter","zygosity","pf","pc","af","hgvsg","ad_ratio","variant_class", "rsnumber", "aa_change", "picked_consequences"
 			]
 	}`
 	req, _ := http.NewRequest("POST", "/occurrences/1/list", bytes.NewBuffer([]byte(body)))
@@ -80,10 +84,14 @@ func Test_OccurrencesListHandler(t *testing.T) {
         "filter": "PASS",
         "zygosity": "HET",
         "pf": 0.99,
+        "pc": 3,
         "af": 0.01,
         "hgvsg": "hgvsg1",
         "ad_ratio": 1.0,
-        "variant_class": "class1"
+        "variant_class": "class1",
+		"rsnumber": "rs111111111",
+		"aa_change": "p.Arg19His",
+		"picked_consequences": ["splice acceptor"]
     }]`, w.Body.String())
 }
 

--- a/backend/internal/types/consequence.go
+++ b/backend/internal/types/consequence.go
@@ -43,10 +43,11 @@ var ConsequenceIdField = Field{
 	Table:           ConsequenceFilterTable,
 }
 
-var SymbolField = Field{
+var SymbolFilterField = Field{
 	Name:            "symbol",
 	CanBeFiltered:   true,
 	CanBeAggregated: true,
+	CanBeSelected:   false,
 	Table:           ConsequenceFilterTable,
 }
 

--- a/backend/internal/types/occurrence.go
+++ b/backend/internal/types/occurrence.go
@@ -10,10 +10,11 @@ type Occurrence struct {
 	Filter              string            `json:"filter,omitempty"`
 	Zygosity            string            `json:"zygosity,omitempty"`
 	Pf                  float64           `json:"pf,omitempty"`
+	Pc                  int               `json:"pc,omitempty"`
 	Af                  float64           `json:"af,omitempty"`
 	GnomadV3Af          float64           `json:"gnomad_v3_af,omitempty"`
 	Hgvsg               string            `json:"hgvsg,omitempty"`
-	OmimInheritanceCode string            `json:"omim_inheritance_code,omitempty"`
+	OmimInheritanceCode JsonArray[string] `gorm:"type:json" json:"omim_inheritance_code,omitempty"`
 	AdRatio             float64           `json:"ad_ratio,omitempty"`
 	VariantClass        string            `json:"variant_class,omitempty"`
 	VepImpact           string            `json:"vep_impact,omitempty"`
@@ -21,6 +22,9 @@ type Occurrence struct {
 	Clinvar             JsonArray[string] `gorm:"type:json" json:"clinvar,omitempty"`
 	ManeSelect          bool              `json:"mane_select,omitempty"`
 	Canonical           bool              `json:"canonical,omitempty"`
+	AaChange            string            `json:"aa_change,omitempty"`
+	RsNumber            string            `json:"rsnumber,omitempty"`
+	PickedConsequences  JsonArray[string] `gorm:"type:json" json:"picked_consequences,omitempty"`
 } // @name Occurrence
 
 var OccurrenceTable = Table{
@@ -57,6 +61,7 @@ var ZygosityField = Field{
 }
 var GenotypeQualityField = Field{
 	Name:          "gq",
+	Alias:         "genotype_quality",
 	CanBeSelected: true,
 	CanBeFiltered: true,
 	Table:         OccurrenceTable,
@@ -84,15 +89,24 @@ var OccurrencesFields = []Field{
 	GenotypeQualityField,
 	AdRatioField,
 	PfField,
+	PcField,
 	AfField,
 	VariantClassField,
 	HgvsgField,
 	ChromosomeField,
 	ClinvarField,
 	ConsequenceIdField,
-	SymbolField,
+	SymbolFilterField,
 	ImpactScoreField,
 	SiftPredField,
 	OmimGenePanelField,
 	HpoGenePanelField,
+	RsNumberField,
+	AaChangeField,
+	ConsequenceField,
+	VepImpactField,
+	SymbolField,
+	ManeSelectField,
+	OmimInheritanceCodeField,
+	GnomadV3AfField,
 }

--- a/backend/internal/types/table_field.go
+++ b/backend/internal/types/table_field.go
@@ -51,12 +51,23 @@ func findByAlias(fields []Field, alias string) *Field {
 
 }
 
+// findByAlias returns the selectable field with the given name from the list of fields
+func findSelectableByAlias(fields []Field, alias string) *Field {
+	if fields == nil {
+		return nil
+	}
+	return sliceutils.Find(fields, func(field Field, index int, slice []Field) bool {
+		return field.GetAlias() == alias && field.CanBeSelected
+	})
+
+}
+
 // findSelectedFields returns the fields that can be selected from the list of string field names
 func findSelectedFields(fields []Field, selected []string) []Field {
 	var selectedFields []Field
 	for _, s := range selected {
-		field := findByAlias(fields, s)
-		if field != nil && field.CanBeSelected {
+		field := findSelectableByAlias(fields, s)
+		if field != nil {
 			selectedFields = append(selectedFields, *field)
 		}
 	}

--- a/backend/internal/types/variant.go
+++ b/backend/internal/types/variant.go
@@ -12,6 +12,13 @@ var PfField = Field{
 	CanBeSorted:   true,
 	Table:         VariantTable,
 }
+var PcField = Field{
+	Name:          "pc",
+	CanBeSelected: true,
+	CanBeFiltered: true,
+	CanBeSorted:   true,
+	Table:         VariantTable,
+}
 var AfField = Field{
 	Name:          "af",
 	CanBeSelected: true,
@@ -44,4 +51,67 @@ var ClinvarField = Field{
 	CanBeAggregated: true,
 	Type:            ArrayType,
 	Table:           VariantTable,
+}
+
+var RsNumberField = Field{
+	Name:          "rsnumber",
+	CanBeSelected: true,
+	CanBeFiltered: true,
+	CanBeSorted:   true,
+	Table:         VariantTable,
+}
+
+var AaChangeField = Field{
+	Name:          "aa_change",
+	CanBeSelected: true,
+	CanBeFiltered: true,
+	CanBeSorted:   true,
+	Table:         VariantTable,
+}
+
+var ConsequenceField = Field{
+	Name:            "consequence",
+	Alias:           "picked_consequences",
+	CanBeSelected:   true,
+	CanBeFiltered:   true,
+	CanBeSorted:     false,
+	CanBeAggregated: true,
+	Type:            ArrayType,
+	Table:           VariantTable,
+}
+var VepImpactField = Field{
+	Name:          "vep_impact",
+	CanBeSelected: true,
+	CanBeFiltered: false,
+	CanBeSorted:   true,
+	Table:         VariantTable,
+}
+var SymbolField = Field{
+	Name:          "symbol",
+	CanBeSelected: true,
+	CanBeFiltered: false,
+	CanBeSorted:   true,
+	Table:         VariantTable,
+}
+var ManeSelectField = Field{
+	Name:          "mane_select",
+	CanBeSelected: true,
+	CanBeFiltered: true,
+	CanBeSorted:   true,
+	Table:         VariantTable,
+}
+var OmimInheritanceCodeField = Field{
+	Name:          "omim_inheritance_code",
+	CanBeSelected: true,
+	CanBeFiltered: true,
+	CanBeSorted:   true,
+	Type:          ArrayType,
+	Table:         VariantTable,
+}
+var GnomadV3AfField = Field{
+	Name:          "gnomad_v3_af",
+	CanBeSelected: true,
+	CanBeFiltered: true,
+	CanBeSorted:   true,
+	Table:         VariantTable,
 }

--- a/backend/test/data/clinvar/variants.tsv
+++ b/backend/test/data/clinvar/variants.tsv
@@ -1,6 +1,6 @@
-locus_id	pf	af	gnomad_v3_af	hgvsg	omim_inheritance_code	variant_class	vep_impact	symbol	clinvar_interpretation	mane_select	canonical
-1000	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	["Likely_Pathogenic", "Pathogenic"]	true	true
-1001	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	["Pathogenic"]	true	true
-1002	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	["Benign"]	true	true
-1003	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	null	true	true
-2000	0.99	0.01	0.001	hgvsg2	code1	class1	impact1	symbol1	["Pathogenic"]	true	true
+locus_id	pf	pc	af	gnomad_v3_af	hgvsg	omim_inheritance_code	variant_class	vep_impact	symbol	clinvar_interpretation	mane_select	canonical
+1000	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	["Likely_Pathogenic", "Pathogenic"]	true	true
+1001	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	["Pathogenic"]	true	true
+1002	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	["Benign"]	true	true
+1003	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	null	true	true
+2000	0.99	2	0.01	0.001	hgvsg2	code1	class1	impact1	symbol1	["Pathogenic"]	true	true

--- a/backend/test/data/consequence/variants.tsv
+++ b/backend/test/data/consequence/variants.tsv
@@ -1,13 +1,13 @@
-locus_id	pf	af	gnomad_v3_af	hgvsg	omim_inheritance_code	variant_class	vep_impact	symbol	mane_select	canonical
-1000	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1001	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1002	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1003	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1004	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1005	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1006	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1007	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1008	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1009	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1010	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-2000	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+locus_id	pf	pc	af	gnomad_v3_af	hgvsg	omim_inheritance_code	variant_class	vep_impact	symbol	mane_select	canonical
+1000	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1001	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1002	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1003	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1004	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1005	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1006	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1007	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1008	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1009	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1010	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+2000	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true

--- a/backend/test/data/gene_panels/variants.tsv
+++ b/backend/test/data/gene_panels/variants.tsv
@@ -1,13 +1,13 @@
-locus_id	pf	af	gnomad_v3_af	hgvsg	omim_inheritance_code	variant_class	vep_impact	symbol	mane_select	canonical
-1000	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1001	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1002	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1003	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1004	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1005	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1006	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1007	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1008	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1009	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1010	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-2000	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+locus_id	pf	pc	af	gnomad_v3_af	hgvsg	omim_inheritance_code	variant_class	vep_impact	symbol	mane_select	canonical
+1000	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1001	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1002	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1003	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1004	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1005	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1006	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1007	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1008	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1009	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1010	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+2000	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true

--- a/backend/test/data/multiple/variants.tsv
+++ b/backend/test/data/multiple/variants.tsv
@@ -1,3 +1,3 @@
-locus_id	pf	af	gnomad_v3_af	hgvsg	omim_inheritance_code	variant_class	vep_impact	symbol	mane_select	canonical
-1000	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-2000	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+locus_id	pf	pc	af	gnomad_v3_af	hgvsg	omim_inheritance_code	variant_class	vep_impact	symbol	mane_select	canonical
+1000	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+2000	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true

--- a/backend/test/data/pagination/variants.tsv
+++ b/backend/test/data/pagination/variants.tsv
@@ -1,31 +1,31 @@
-locus_id	pf	af	gnomad_v3_af	hgvsg	omim_inheritance_code	variant_class	vep_impact	symbol	mane_select	canonical
-1000	0.01	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1001	0.02	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1002	0.03	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1003	0.04	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1004	0.05	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1005	0.06	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1006	0.07	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1007	0.08	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1008	0.09	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1009	0.10	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1010	0.11	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1011	0.12	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1012	0.13	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1013	0.14	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1014	0.15	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1015	0.16	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1016	0.17	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1017	0.18	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1018	0.19	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1019	0.20	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1020	0.21	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1021	0.22	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1022	0.23	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1023	0.24	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1024	0.25	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1025	0.26	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1026	0.27	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1027	0.28	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-1028	0.29	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
-2000	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+locus_id	pf	pc	af	gnomad_v3_af	hgvsg	omim_inheritance_code	variant_class	vep_impact	symbol	mane_select	canonical
+1000	0.01	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1001	0.02	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1002	0.03	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1003	0.04	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1004	0.05	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1005	0.06	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1006	0.07	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1007	0.08	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1008	0.09	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1009	0.10	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1010	0.11	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1011	0.12	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1012	0.13	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1013	0.14	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1014	0.15	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1015	0.16	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1016	0.17	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1017	0.18	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1018	0.19	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1019	0.20	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1020	0.21	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1021	0.22	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1022	0.23	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1023	0.24	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1024	0.25	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1025	0.26	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1026	0.27	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1027	0.28	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+1028	0.29	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true
+2000	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true

--- a/backend/test/data/simple/variants.tsv
+++ b/backend/test/data/simple/variants.tsv
@@ -1,3 +1,3 @@
-locus_id	pf	af	gnomad_v3_af	hgvsg	omim_inheritance_code	variant_class	vep_impact	symbol	mane_select	canonical	clinvar_interpretation
-1000	0.99	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true	"[""Benign"", ""Pathogenic""]"
-2000	0.99	0.01	0.001	hgvsg2	code1	class1	impact1	symbol1	true	true	"[""Benign""]"
+locus_id	pf	pc	af	gnomad_v3_af	hgvsg	omim_inheritance_code	variant_class	vep_impact	symbol	mane_select	canonical	clinvar_interpretation	rsnumber	aa_change	consequence
+1000	0.99	3	0.01	0.001	hgvsg1	code1	class1	impact1	symbol1	true	true	["Benign", "Pathogenic"]	rs111111111	p.Arg19His	["splice acceptor"]
+2000	0.99	2	0.01	0.001	hgvsg2	code1	class1	impact1	symbol1	true	true	["Benign"]	rs222222222	p.Arg19His	["splice acceptor"]

--- a/backend/test/data/sql/variants.sql
+++ b/backend/test/data/sql/variants.sql
@@ -23,5 +23,6 @@ CREATE TABLE `variants`
     `alternate`              varchar(2000),
     `hgvsg`                  varchar(2000) NULL,
     `locus_full`             varchar(2000) NULL,
-    `dna_change`             varchar(2000)
+    `dna_change`             varchar(2000),
+    `aa_change`             varchar(2000) NULL COMMENT ""
 ) ENGINE = OLAP


### PR DESCRIPTION
J'ai du ajouter findSelectableByAlias car sinon le `sliceutils.Find` renvoie le premier qu'il trouve et pour certains champs on a 2 fields (un pour le filtrage et un pour l'affichage) selon l'ordre dans lequel ils étaient dans la liste, on ne prenait pas le bon.