### PR TITLE
🐛 Fix interpretation tooltip glitch

### DIFF
--- a/frontend/apps/variant-exploration/src/feature/interpretation/interpretation-dialog.tsx
+++ b/frontend/apps/variant-exploration/src/feature/interpretation/interpretation-dialog.tsx
@@ -10,7 +10,7 @@ import {
 import { Separator } from '@/components/base/ui/separator';
 import { Edit2Icon } from 'lucide-react';
 import InterpretationFormGermline from './interpretation-form-germline';
-import { useCallback, useRef, useState } from 'react';
+import { ReactNode, useCallback, useRef, useState } from 'react';
 import { Occurrence } from '@/api/api';
 import InterpretationFormSomatic from './interpretation-form-somatic';
 import InterpretationLastUpdatedBanner from './last-updated-banner';
@@ -21,15 +21,16 @@ import useSWRMutation from 'swr/mutation';
 import { Interpretation, InterpretationFormRef } from './types';
 import { Spinner } from '@/components/base/spinner';
 
-type InterpretationDialogButtonProps = ButtonProps & {
+type InterpretationDialogButtonProps = {
   occurrence: Occurrence;
+  renderTrigger: (handleOpen: () => void) => ReactNode;
 };
 
 // Temporary flag to switch between somatic and germline interpretation forms
 // In the future, this should be determined based on the occurrence type or other criteria
 const isSomatic = false;
 
-function InterpretationDialogButton({ occurrence, children, ...buttonProps }: InterpretationDialogButtonProps) {
+function InterpretationDialog({ occurrence, renderTrigger }: InterpretationDialogButtonProps) {
   const [open, setOpen] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
   const gerlimeFormRef = useRef<InterpretationFormRef>(null);
@@ -71,9 +72,7 @@ function InterpretationDialogButton({ occurrence, children, ...buttonProps }: In
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <Button color="primary" onClick={handleOpen} {...buttonProps}>
-        {children}
-      </Button>
+      {renderTrigger(handleOpen)}
       <DialogContent
         className="max-w-[calc(100vw-48px)] min-h-[calc(100vh-48px)] w-[1200px]"
         onEscapeKeyDown={e => e.preventDefault()}
@@ -142,4 +141,4 @@ function InterpretationDialogButton({ occurrence, children, ...buttonProps }: In
   );
 }
 
-export default InterpretationDialogButton;
+export default InterpretationDialog;

--- a/frontend/apps/variant-exploration/src/feature/occurrence-table/cells/interpretation-cell.tsx
+++ b/frontend/apps/variant-exploration/src/feature/occurrence-table/cells/interpretation-cell.tsx
@@ -1,7 +1,8 @@
 import { Occurrence } from '@/api/api';
+import { Button } from '@/components/base/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/ui/tooltip';
 import { useI18n } from '@/components/hooks/i18n';
-import InterpretationDialogButton from '@/feature/interpretation/interpretation-dialog-button';
+import InterpretationDialog from '@/feature/interpretation/interpretation-dialog';
 import { ZapIcon } from 'lucide-react';
 
 type InterpretationCellProps = {
@@ -11,21 +12,19 @@ type InterpretationCellProps = {
 function InterpretationCell({ occurrence }: InterpretationCellProps) {
   const { t } = useI18n();
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span>
-          <InterpretationDialogButton
-            iconOnly
-            variant="ghost"
-            className="text-muted-foreground size-5"
-            occurrence={occurrence}
-          >
-            <ZapIcon size={16} />
-          </InterpretationDialogButton>
-        </span>
-      </TooltipTrigger>
-      <TooltipContent>{t('variant.interpretation.tooltips')}</TooltipContent>
-    </Tooltip>
+    <InterpretationDialog
+      occurrence={occurrence}
+      renderTrigger={handleOpen => (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button iconOnly className="size-6" variant="ghost" onClick={handleOpen}>
+              <ZapIcon size={16} className="text-muted-foreground cursor-pointer" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('variant.interpretation.tooltips')}</TooltipContent>
+        </Tooltip>
+      )}
+    />
   );
 }
 

--- a/frontend/apps/variant-exploration/src/feature/occurrence-table/occurrence-expend-header.tsx
+++ b/frontend/apps/variant-exploration/src/feature/occurrence-table/occurrence-expend-header.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/base/ui/button';
 import { Download, Edit2Icon, SquareArrowOutUpRightIcon } from 'lucide-react';
-import InterpretationDialogButton from '../interpretation/interpretation-dialog-button';
+import InterpretationDialog from '../interpretation/interpretation-dialog';
 import VariantIcon from '@/components/base/icons/variant-icon';
 import { Occurrence } from '@/api/api';
 import { useI18n } from '@/components/hooks/i18n';
@@ -27,9 +27,14 @@ export default function OccurrenceExpendHeader({ occurrence }: OccurrenceExpendH
       </Button>
       <div className="flex items-center gap-5">
         <div className="flex gap-2">
-          <InterpretationDialogButton color="primary" size="xs" occurrence={occurrence}>
-            <Edit2Icon /> {t('occurrenceExpend.actions.interpret')}
-          </InterpretationDialogButton>
+          <InterpretationDialog
+            occurrence={occurrence}
+            renderTrigger={handleOpen => (
+              <Button size="xs" onClick={handleOpen}>
+                <Edit2Icon /> {t('occurrenceExpend.actions.interpret')}
+              </Button>
+            )}
+          />
           <Button color="primary" size="xs">
             <Download />
             {t('occurrenceExpend.actions.downloadReport')}

--- a/frontend/components/base/data-table/data-table-header-actions.tsx
+++ b/frontend/components/base/data-table/data-table-header-actions.tsx
@@ -13,7 +13,6 @@ import { Tooltip } from '@radix-ui/react-tooltip';
 import { Button } from '@/components/base/ui/button';
 import { TFunction } from 'i18next';
 import { ColumnPinningPosition, Header, SortDirection } from '@tanstack/react-table';
-import { boolean } from 'zod';
 import { useState } from 'react';
 
 const PIN_COLUMN_ACTIONS: {
@@ -84,7 +83,7 @@ function TableHeaderActions({ header }: TableHeaderActionsProps<any>) {
             <Button
               variant="ghost"
               iconOnly
-              className={cn('size-5', {
+              className={cn('size-6', {
                 'opacity-0 group-hover:opacity-100': !isPinningDropdownActive,
               })}
             >
@@ -117,7 +116,7 @@ function TableHeaderActions({ header }: TableHeaderActionsProps<any>) {
             <Button
               variant="ghost"
               iconOnly
-              className={cn('size-5', {
+              className={cn('size-6', {
                 'opacity-0 group-hover:opacity-100': !header.column.getIsSorted(),
               })}
               onClick={header.column.getToggleSortingHandler()}


### PR DESCRIPTION
The tooltip was wrapping the entire Dialog component, causing the tooltip to open unexpectedly.